### PR TITLE
Add dirent writeable directory example

### DIFF
--- a/dirent-writeable-directory/README.MD
+++ b/dirent-writeable-directory/README.MD
@@ -1,0 +1,6 @@
+# Create Writeable Directory
+This example shows how to create a writeable directory using a [Dirent](https://www.commonwl.org/v1.2/CommandLineTool.html#Dirent) InitialWorkDirRequirement before executing the tool.
+
+The entry expression on line 12 can be replaced by other javascript expressions to create files like config files prior to executing the tool.
+
+The example also shows how to use the [ShellCommandRequirement](https://www.commonwl.org/v1.2/CommandLineTool.html#ShellCommandRequirement) to embed metacharacters like `>` or `|` into your shell command without wrapping them with quotes.

--- a/dirent-writeable-directory/README.MD
+++ b/dirent-writeable-directory/README.MD
@@ -1,6 +1,6 @@
 # Create Writeable Directory
-This example shows how to create a writeable directory using a [Dirent](https://www.commonwl.org/v1.2/CommandLineTool.html#Dirent) InitialWorkDirRequirement before executing the tool.
+This example shows how to create a writeable directory prior to executing the tool by using a [Dirent](https://www.commonwl.org/v1.2/CommandLineTool.html#Dirent) InitialWorkDirRequirement.
 
-The entry expression on line 12 can be replaced by other javascript expressions to create files like config files prior to executing the tool.
+The entry expression on line 12 can be replaced by other javascript expressions to create files like config files.
 
-The example also shows how to use the [ShellCommandRequirement](https://www.commonwl.org/v1.2/CommandLineTool.html#ShellCommandRequirement) to embed metacharacters like `>` or `|` into your shell command without wrapping them with quotes.
+The example also shows how to use the [ShellCommandRequirement](https://www.commonwl.org/v1.2/CommandLineTool.html#ShellCommandRequirement) to embed metacharacters like `>` or `|` into your shell commands which would otherwise be wrapped by quotes.

--- a/dirent-writeable-directory/output.txt
+++ b/dirent-writeable-directory/output.txt
@@ -1,0 +1,1 @@
+Hello World

--- a/dirent-writeable-directory/test.cwl
+++ b/dirent-writeable-directory/test.cwl
@@ -1,0 +1,29 @@
+#!/usr/bin/env cwl-runner
+
+cwlVersion: v1.2
+class: CommandLineTool
+baseCommand: echo
+requirements:
+    InlineJavascriptRequirement: {}
+    ShellCommandRequirement: {}
+    InitialWorkDirRequirement:
+        listing:
+            - entryname: out
+              entry: "$({class: 'Directory', listing: []})"
+              writable: true
+arguments:
+    - valueFrom: '>'
+      shellQuote: false
+      position: 2
+    - valueFrom: $(runtime.outdir)/out/output.txt
+      position: 3
+inputs:
+    text:
+        type: string
+        inputBinding:
+            position: 1
+outputs:
+    out_file:
+        type: File
+        outputBinding:
+            glob: $(runtime.outdir)/out/output.txt 

--- a/dirent-writeable-directory/testRun.yml
+++ b/dirent-writeable-directory/testRun.yml
@@ -1,0 +1,1 @@
+text: "Hello World"


### PR DESCRIPTION
This example shows how to create a writeable directory prior to executing the tool by using a [Dirent](https://www.commonwl.org/v1.2/CommandLineTool.html#Dirent) InitialWorkDirRequirement.

The example also shows how to use the [ShellCommandRequirement](https://www.commonwl.org/v1.2/CommandLineTool.html#ShellCommandRequirement) to embed metacharacters like `>` or `|` into your shell commands which would otherwise be wrapped by quotes.
