### PR TITLE
Add writeable directory example

### DIFF
--- a/writeable-directory/README.md
+++ b/writeable-directory/README.md
@@ -1,0 +1,4 @@
+# Create Writeable Directory
+This example shows how to create a writeable directory prior to executing the tool by using [InitialWorkDirRequirement](https://www.commonwl.org/v1.2/CommandLineTool.html#InitialWorkDirRequirement) with a Directory entry.
+
+The example also shows how to use the [ShellCommandRequirement](https://www.commonwl.org/v1.2/CommandLineTool.html#ShellCommandRequirement) to embed metacharacters like `>` or `|` into your shell commands which would otherwise be wrapped by quotes.

--- a/writeable-directory/output.txt
+++ b/writeable-directory/output.txt
@@ -1,0 +1,1 @@
+Hello World

--- a/writeable-directory/test.cwl
+++ b/writeable-directory/test.cwl
@@ -1,0 +1,28 @@
+#!/usr/bin/env cwl-runner
+
+cwlVersion: v1.2
+class: CommandLineTool
+baseCommand: echo
+requirements:
+    ShellCommandRequirement: {}
+    InitialWorkDirRequirement:
+        listing:
+            - class: Directory
+              basename: out
+              listing: []
+arguments:
+    - valueFrom: '>'
+      shellQuote: false
+      position: 2
+    - valueFrom: $(runtime.outdir)/out/output.txt
+      position: 3
+inputs:
+    text:
+        type: string
+        inputBinding:
+            position: 1
+outputs:
+    out_file:
+        type: File
+        outputBinding:
+            glob: $(runtime.outdir)/out/output.txt 

--- a/writeable-directory/testRun.yml
+++ b/writeable-directory/testRun.yml
@@ -1,0 +1,1 @@
+text: "Hello World"


### PR DESCRIPTION
This example shows how to create a writeable directory prior to executing the tool by using [InitialWorkDirRequirement](https://www.commonwl.org/v1.2/CommandLineTool.html#InitialWorkDirRequirement) with a Directory entry.

The example also shows how to use the [ShellCommandRequirement](https://www.commonwl.org/v1.2/CommandLineTool.html#ShellCommandRequirement) to embed metacharacters like `>` or `|` into your shell commands which would otherwise be wrapped by quotes.